### PR TITLE
fix: fix slice init length

### DIFF
--- a/app/services/mass_msg.go
+++ b/app/services/mass_msg.go
@@ -367,7 +367,7 @@ func (o MassMsgService) Notify(ids []string, extCorpID string) error {
 		err = errors.WithStack(err)
 		return err
 	}
-	extStaffIDs := make([]string, len(staffCustomerIDs))
+	extStaffIDs := make([]string, 0, len(staffCustomerIDs))
 	for _, staffCustomer := range staffCustomerIDs {
 		extStaffIDs = append(extStaffIDs, staffCustomer.ExtStaffID)
 


### PR DESCRIPTION
The intention here should be to initialize a slice with a capacity of len(staffCustomerIDs)  rather than initializing the length of this slice. 

The online demo: https://go.dev/play/p/q1BcVCmvidW